### PR TITLE
Crash fx crash fix

### DIFF
--- a/lovely.toml
+++ b/lovely.toml
@@ -3393,6 +3393,17 @@ match_indent = true
 payload = '''if not from_debuff then
 '''
 
+# for smods before 0404
+[[patches]]
+[patches.pattern]
+target = 'card.lua'
+pattern = "if G.GAME.blind and G.GAME.blind.in_blind then G.E_MANAGER:add_event(Event({ func = function() G.GAME.blind:set_blind(nil, true, nil); return true end })) end"
+position = 'before'
+match_indent = true
+payload = '''end
+'''
+
+# for smods after 0404
 [[patches]]
 [patches.pattern]
 target = 'card.lua'


### PR DESCRIPTION
Put the old lovely patch back so people trying to use old SMODS don't crash on start instead. This doesn't affect people using new SMODS because the patch won't do anything in that case. I feel very silly for not thinking of this earlier.

There may be a more elegant way to do this but :woman_shrugging: 