### PR TITLE
Better cross-mod compatiblity for Spectrum detection

### DIFF
--- a/Bunco.lua
+++ b/Bunco.lua
@@ -74,7 +74,25 @@ end
 -- Exotic in_pool function
 
 BUNCOMOD.funcs.exotic_in_pool = function()
-    return G.GAME and G.GAME.Exotic
+    if G.GAME and G.GAME.Exotic then return true end
+    --In case a Spectrum somehow gets played without enabling exotics, check directly:
+    local spectrum_played = false
+    if G and G.GAME and G.GAME.hands then
+        for k, v in pairs(G.GAME.hands) do
+            if string.find(k, "Spectrum", nil, true) then
+                if G.GAME.hands[k].played > 0 then
+                    spectrum_played = true
+                    break
+                end
+            end
+        end
+    end
+
+    if spectrum_played and (SMODS.Mods["Bunco"] or {}).can_load then
+        if not exotic_in_pool() then enable_exotics() end
+    end
+
+    return spectrum_played
 end
 
 -- Dictionary wrapper

--- a/Bunco.lua
+++ b/Bunco.lua
@@ -88,10 +88,6 @@ BUNCOMOD.funcs.exotic_in_pool = function()
         end
     end
 
-    if spectrum_played and (SMODS.Mods["Bunco"] or {}).can_load then
-        if not exotic_in_pool() then enable_exotics() end
-    end
-
     return spectrum_played
 end
 

--- a/lovely.toml
+++ b/lovely.toml
@@ -12,10 +12,7 @@ position = 'after'
 match_indent = true
 payload = '''
 
-if text == 'bunc_Spectrum'
-or text == 'bunc_Straight Spectrum'
-or text == 'bunc_Spectrum House'
-or text == 'bunc_Spectrum Five' then
+if string.find(text, "Spectrum") then
     enable_exotics()
     unlock_card(G.P_CENTERS.b_bunc_fairy)
 end


### PR DESCRIPTION
Use `string.find` instead of four exact matches; if this somehow fails check this game's hand count directly.