### PR TITLE
Fix stack overflow with All in Jest

### DIFF
--- a/Bunco.lua
+++ b/Bunco.lua
@@ -1140,7 +1140,8 @@ SMODS.Tag:take_ownership('double', {
 -- AiJ implemented this in a way that usually specific compat isn't required
 -- However in this case I did weird stuff, so putting in a specific fix
 -- Used in Prehistoric Joker
-ids_op = next(SMODS.find_mod("allinjest")) and ids_op or function (card, op, b)
+-- Post fix addendum: Why would you name it the same exact thing????
+aij_ids_op = next(SMODS.find_mod("allinjest")) and ids_op or function (card, op, b)
     return card:get_id() == b
 end
 
@@ -1705,7 +1706,7 @@ create_joker({ -- Prehistoric
     calculate = function(self, card, context)
         if context.individual and context.cardarea == G.play then
             for _, v in ipairs(card.ability.extra.card_list) do
-                if (ids_op(context.other_card, '==', v.rank))
+                if (aij_ids_op(context.other_card, '==', v.rank))
                 and (v.has_any_suit or context.other_card:is_suit(v.suit)) then
                     return {
                         mult = card.ability.extra.mult,

--- a/compat/jokerdisplay.lua
+++ b/compat/jokerdisplay.lua
@@ -174,7 +174,7 @@ jd_def["j_bunc_prehistoric"] = { -- Prehistoric Joker
             for _, scoring_card in pairs(scoring_hand) do
                 if not(SMODS.has_no_suit(scoring_card) or SMODS.has_no_rank(scoring_card)) then
                     for _, previously_played_card in pairs(card_list) do
-                        if (ids_op(scoring_card, '==', previously_played_card.rank))
+                        if (aij_ids_op(scoring_card, '==', previously_played_card.rank))
                             and (previously_played_card.has_any_suit or scoring_card:is_suit(previously_played_card.suit)) then
                             mult = mult +
                                 card.ability.extra.mult *


### PR DESCRIPTION
With the function being named `ids_op`... and then All in Jest patching the dummy function for that `ids_op`... This would cause an infinite loop, and therefore a stack overflow.

This is fixed by simply renaming the function.