### PR TITLE
Remove redundant Blue Seal patch

### DIFF
--- a/lovely.toml
+++ b/lovely.toml
@@ -1015,21 +1015,6 @@ payload = '''
 if hand == 'bunc_Deal' then return end
 '''
 
-# Deal hand crash fix for Blue Seal
-[[patches]]
-[patches.pattern]
-target = 'card.lua'
-pattern = "local card = create_card(card_type,G.consumeables, nil, nil, nil, nil, _planet, 'blusl')"
-position = 'before'
-match_indent = true
-payload = '''
-
-if _planet == 0 then
-    _planet = 'c_pluto'
-end
-
-'''
-
 # function level_up_hand (Head in the Clouds)
 [[patches]]
 [patches.pattern]


### PR DESCRIPTION
SMODS now has its own fix to prevent a Blue Seal crash, so Bunco's can be removed:
```lua
if _planet == 0 then _planet = nil end -- <- SMODS

if _planet == 0 then    --
    _planet = 'c_pluto' -- <- Bunco
end                     --
```