### PR TITLE
Fix shader issue during boot

### DIFF
--- a/assets/shaders/splash.fs
+++ b/assets/shaders/splash.fs
@@ -4,12 +4,12 @@
 	#define MY_HIGHP_OR_MEDIUMP mediump
 #endif
 
-MY_HIGHP_OR_MEDIUMP extern number time;
-MY_HIGHP_OR_MEDIUMP extern number vort_speed;
-MY_HIGHP_OR_MEDIUMP extern vec4 colour_1;
-MY_HIGHP_OR_MEDIUMP extern vec4 colour_2;
-MY_HIGHP_OR_MEDIUMP extern number mid_flash;
-MY_HIGHP_OR_MEDIUMP extern number vort_offset;
+extern MY_HIGHP_OR_MEDIUMP number time;
+extern MY_HIGHP_OR_MEDIUMP number vort_speed;
+extern MY_HIGHP_OR_MEDIUMP vec4 colour_1;
+extern MY_HIGHP_OR_MEDIUMP vec4 colour_2;
+extern MY_HIGHP_OR_MEDIUMP number mid_flash;
+extern MY_HIGHP_OR_MEDIUMP number vort_offset;
 
 #define BLACK 0.6*vec4(79./255.,99./255., 103./255., 1./0.6)
 


### PR DESCRIPTION
In some devices Bunco can't boot due to shader errors

```
Cannot compile pixel shader code:
Line 6: ERROR: '' : invalid storage qualifier order 
Line 7: ERROR: '' : invalid storage qualifier order 
Line 8: ERROR: '' : invalid storage qualifier order 
Line 9: ERROR: '' : invalid storage qualifier order 
Line 10: ERROR: '' : invalid storage qualifier order 
Line 11: ERROR: '' : invalid storage qualifier order 

Additional Context:
Balatro Version: 1.0.1o-FULL
Modded Version: 1.0.0~BETA-1016c-STEAMODDED
LÖVE Version: 11.5.0
Lovely Version: 0.8.0
Platform: Windows
Steamodded Mods:
    1: Bunco by Firch, RENREN, Peas, minichibis, J.D., Guwahavel, Ciirulean, ejwu [ID: Bunco, Priority: -1, Version: 5.4.8~JumboFork]
Lovely Mods:
```