### PR TITLE
CardArea:align_cards() patch fix

### DIFF
--- a/lovely.toml
+++ b/lovely.toml
@@ -1306,10 +1306,12 @@ match_indent = true
 payload = '''
 
 for k, card in ipairs(self.cards) do
-    if card.config.center.key == 'j_bunc_taped' and (card.config.center.discovered or card.bypass_discovery_center) then
-        if not card.states.drag.is then
-            card.T.x = card.T.x + (0.18 * card.T.w)
-            card.T.y = card.T.y - (0.01 * card.T.h)
+    if card.config.center then
+        if card.config.center.key == 'j_bunc_taped' and (card.config.center.discovered or card.bypass_discovery_center) then
+            if not card.states.drag.is then
+                card.T.x = card.T.x + (0.18 * card.T.w)
+                card.T.y = card.T.y - (0.01 * card.T.h)
+            end
         end
     end
 end


### PR DESCRIPTION
Pokermon's config / credits / artist / art collection tab uses the "emplace" function to build its UI. With Bunco installed, lovely's cardarea.lua crashes at
```if card.config.center.key == 'j_bunc_taped' and (card.config.center.discovered or card.bypass_discovery_center) then```
Specifically searching for card.config.center.discovered, in an instance where there is not a card.config.center, and thusly spits out the error "attempt to index field 'center' (a nil value)"
By simply adding an "if card.config.center" statement enclosing the bunco patch, Pokermon and j_bunc_taped now work smoothly